### PR TITLE
adding demo and roles subdirectory

### DIFF
--- a/demo/check_changes.sh
+++ b/demo/check_changes.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+ 
+# CHECK OCP (Note Files may change after update)
+ 
+for worker in `oc get nodes|awk '/worker/{print $1}'`; do
+  echo "Checking node $worker ------------------------------------------------------------------------------"
+  # Check for additional kernelmodules
+  oc debug node/$worker -- chroot /host cat /etc/crio/crio.conf.d/90-default-capabilities  2> /dev/null
+  # Check for additional kernelmodules
+  oc debug node/$worker -- chroot /host cat /etc/modules-load.d/sdi-dependencies.conf 2> /dev/null
+  # check for module load service
+  oc debug node/$worker -- chroot /host systemctl status sdi-modules-load.service 2> /dev/null
+  # check for pidsLimit:
+  oc debug node/$worker -- chroot /host cat /etc/crio/crio.conf.d/01-ctrcfg-pidsLimit
+  echo "--------------------------------------------------------------------------------------------------------"
+done

--- a/demo/configure-sdi-observer-registry.sh
+++ b/demo/configure-sdi-observer-registry.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+ 
+  ## Change Namespace to sdi-observer
+  NAMESPACE="${NAMESPACE:-sdi-observer}"
+  oc project sdi-observer
+ 
+  ## Obtain registry credentials
+  reg_credentials=$(oc get -n "${NAMESPACE:-sdi-observer}" secret/container-image-registry-htpasswd -o jsonpath='{.data.\.htpasswd\.raw }'  | base64 -d )
+  reg_user=$(echo $reg_credentials| cut -d: -f1)
+  reg_pw=$(echo $reg_credentials| cut -d: -f2)
+ 
+  ## Obtain registry hostname
+  reg_hostname="$(oc get route -n "${NAMESPACE:-sdi-observer}" container-image-registry -o jsonpath='{.spec.host}')"
+  echo "=================================================" | tee registry-credentials.txt
+  echo "Using registry: $reg_hostname"                     | tee -a registry-credentials.txt
+  echo "USER: $reg_user"                                   | tee -a registry-credentials.txt
+  echo "PW  : $reg_pw"                                     | tee -a registry-credentials.txt
+  echo "=================================================" | tee -a registry-credentials.txt
+ 
+  if [ -z "$reg_user" -o -z "$reg_pw" ]; then
+             echo "Something went wrong. Check if the pods are running"
+             exit 1
+  fi
+ 
+  #set -x
+  ### Obtain Ingress Router's default self-signed CA certificate
+  mkdir -p "/etc/containers/certs.d/${reg_hostname}"
+  router_ca_crt="/etc/containers/certs.d/${reg_hostname}/router-ca.crt"
+  oc get secret -n openshift-ingress-operator -o json router-ca | \
+      jq -r '.data as $d | $d | keys[] | select(test("\\.crt$")) | $d[.] ' | base64 -d > ${router_ca_crt}
+ 
+  ### test via curl
+  curl -k -I --user ${reg_credentials}  --cacert ${router_ca_crt} "https://${reg_hostname}/v2/"
+ 
+  ### test via podman
+  echo $reg_pw |  podman login -u $reg_user --password-stdin ${reg_hostname}
+ 
+  reg_login_ok=$?
+ 
+  if [ $reg_login_ok ]; then
+    # Configure Openshift to trust container registry (8.2)
+    echo "Configure Openshift to trust container registry"
+    echo "CTRL-C to stop, ENTER to continue"
+    read zz
+    caBundle="$(oc get -n openshift-ingress-operator -o json secret/router-ca | \
+      jq -r '.data as $d | $d | keys[] | select(test("\\.(?:crt|pem)$")) | $d[.]' | base64 -d)"
+    # determine the name of the CA configmap if it exists already
+    cmName="$(oc get images.config.openshift.io/cluster -o json | \
+      jq -r '.spec.additionalTrustedCA.name // "trusted-registry-cabundles"')"
+    if oc get -n openshift-config "cm/$cmName" 2>/dev/null; then
+      # configmap already exists -> just update it
+      oc get -o json -n openshift-config "cm/$cmName" | \
+          jq '.data["'"${reg_hostname//:/..}"'"] |= "'"$caBundle"'"' | \
+          oc replace -f - --force
+    else
+        # creating the configmap for the first time
+        oc create configmap -n openshift-config "$cmName" \
+            --from-literal="${reg_hostname//:/..}=$caBundle"
+        oc patch images.config.openshift.io cluster --type=merge \
+            -p '{"spec":{"additionalTrustedCA":{"name":"'"$cmName"'"}}}'
+    fi
+    # Check that the certifcate is deployed
+    sleep 20 # wait for distribution of certificates
+    echo "======== Configured Registries =========="
+    oc rsh -n openshift-image-registry "$(oc get pods -n openshift-image-registry -l docker-registry=default | \
+          awk '/Running/ {print $1; exit}')" ls -1 /etc/pki/ca-trust/source/anchors
+     
+  else
+    echo "Registry setup failed, please repair before you continue"
+  fi
+

--- a/demo/deploy-sdi-observer.yml
+++ b/demo/deploy-sdi-observer.yml
@@ -1,0 +1,138 @@
+---
+- name: Prepare OCP Worker Nodes for SDI
+  hosts: ocp
+
+  vars_prompt:
+         - name: "guid"
+           prompt: "Enter GUID"
+           private: no
+           default: "{{ lookup('env', 'GUID') }}"
+
+         - name: "ocadmin"
+           prompt: "User"
+           private: no
+           default: "admin"
+
+         - name: "ocpass"
+           prompt: "password"
+           private: yes
+
+         - name: "ocapi"
+           prompt: "OpenShift API"
+           private: no
+           default: "https://api.cluster-{{  lookup('env', 'GUID') }}.dynamic.opentlc.com:6443"
+           #default: https://api.cluster-{{ guid }}.{{ guid }}.example.opentlc.com:6443
+
+
+  module_defaults:
+      group/k8s:
+        host: "{{ ocapi }}"
+        validate_certs: no
+
+  tasks:
+  - block:
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: "{{ ocadmin }}"
+        password: "{{ ocpass }}"
+      register: k8s_auth_results
+
+    - name: Ensure Projects for SDI and SDI Observer are created
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: present
+        api_version: project.openshift.io/v1
+        kind: Project
+        name: "{{ namespace }}"
+      loop:
+        - sdi-observer 
+        - sdi
+        - sap-slcbridge
+      loop_control:
+        loop_var: namespace
+
+    - name: Create Secret 
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: present
+        namespace: sdi-observer
+        definition: "{{ lookup('file', './rht-registry-secret.yaml') | from_yaml }}"
+      register: sdi_observer_secret
+    
+    - name: debug secret
+      debug:
+              var: sdi_observer_secret
+
+    - name: debug secret
+      debug:
+              msg: "Secret name: {{ sdi_observer_secret.result.metadata.name }}"
+
+    # Ugly: Replace by community.okd.openshift_process
+    # Install: ansible-galaxy collection install community.okd
+    # https://galaxy.ansible.com/community/okd?extIdCarryOver=true&sc_cid=701f2000001OH6uAAG
+    - name: Update template for SDI observer
+      shell: |
+         NAMESPACE=sdi-observer
+         SDI_NAMESPACE=sdi
+         SLCB_NAMESPACE=sap-slcbridge
+         OCP_MINOR_RELEASE=4.7
+         #NODE_LOG_FORMAT=text
+         DEPLOY_SDI_REGISTRY=true
+         INJECT_CABUNDLE=true
+         #BUNDLE_SECRET_NAME=openshift-ingress-operator/router-ca
+         MANAGE_VSYSTEM_ROUTE=true
+         REDHAT_REGISTRY_SECRET_NAME={{ sdi_observer_secret.result.metadata.name }}
+         SDI_NODE_SELECTOR=node-role.kubernetes.io/sdi=
+         
+         oc process -f https://raw.githubusercontent.com/redhat-sap/sap-data-intelligence/master/observer/ocp-template.json \
+                 NAMESPACE="${NAMESPACE:-sdi-observer}" \
+                 SDI_NAMESPACE="${SDI_NAMESPACE:-sdi}" \
+                 SLCB_NAMESPACE="${SLCB_NAMESPACE:-sap-slcbridge}" \
+                 OCP_MINOR_RELEASE="${OCP_MINOR_RELEASE:-4.7}" \
+                 DEPLOY_SDI_REGISTRY="${DEPLOY_SDI_REGISTRY:-true}" \
+                 INJECT_CABUNDLE="${INJECT_CABUNDLE:-true}" \
+                 MANAGE_VSYSTEM_ROUTE="${MANAGE_VSYSTEM_ROUTE:-true}" \
+                 SDI_NODE_SELECTOR="${SDI_NODE_SELECTOR}" \
+                 REDHAT_REGISTRY_SECRET_NAME="$REDHAT_REGISTRY_SECRET_NAME"
+      register: deploy_sdi_observer_config
+
+    - name: Output SDI Observer Config
+      debug: 
+        msg: "{{  deploy_sdi_observer_config.stdout }}"
+      
+
+    - name: Ensure SDI Observer is launched
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: present
+        namespace: sdi-observer
+        definition: "{{ deploy_sdi_observer_config.stdout }}"
+
+    - name: Output of account setup
+      debug:
+        msg: "{{  deploy_sdi_observer_config.stdout }}"
+
+
+    # Ugly: need to have proper privileges locally
+    - name: Ensure SDI account is setup properly
+      shell: | 
+        oc login --insecure-skip-tls-verify=true   -u {{ ocadmin }} -p {{ ocpass }} {{ ocapi }}
+        oc project sdi
+        oc adm policy add-scc-to-group anyuid "system:serviceaccounts:$(oc project -q)"
+        oc adm policy add-scc-to-user privileged -z "$(oc project -q)-elasticsearch"
+        oc adm policy add-scc-to-user privileged -z "$(oc project -q)-fluentd"
+        oc adm policy add-scc-to-user privileged -z default
+        oc adm policy add-scc-to-user privileged -z mlf-deployment-api
+        oc adm policy add-scc-to-user privileged -z vora-vflow-server
+        oc adm policy add-scc-to-user privileged -z "vora-vsystem-$(oc project -q)"
+        oc adm policy add-scc-to-user privileged -z "vora-vsystem-$(oc project -q)-vrep"
+      register: deploy_sdi_observer_priviledge_setup
+
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+

--- a/demo/get-storage-credentials.sh
+++ b/demo/get-storage-credentials.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+oc project sdi-infra
+for claimName in sdi-checkpoint-store sdi-data-lake; do
+   printf 'Bucket/claim %s:\n  Endpoint:\thttp://s3.openshift-storage.svc.cluster.local\n  Bucket name:\t%s\n' "$claimName" "$(oc get obc -o jsonpath='{.spec.bucketName}' "$claimName")"
+   for key in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+     printf '  %s:\t%s\n' "$key" "$(oc get secret "$claimName" -o jsonpath="{.data.$key}" | base64 -d)"
+   done
+done | column -t -s $'\t' | tee storage-credentials.txt

--- a/demo/hosts.example
+++ b/demo/hosts.example
@@ -1,0 +1,2 @@
+[ocp]
+bastion.bd63.dynamic.opentlc.com ansible_user=generic_emea_mkoch

--- a/demo/oc-list-nodes.yml
+++ b/demo/oc-list-nodes.yml
@@ -1,0 +1,71 @@
+---
+- name: get OCP node info
+  hosts: ocp
+
+  vars_prompt:
+         - name: "guid"
+           prompt: "Enter GUID"
+           private: no
+           default: "{{ lookup('env', 'GUID') }}"
+
+         - name: "ocadmin"
+           prompt: "User"
+           private: no
+           default: "admin"
+
+         - name: "ocpass"
+           prompt: "password"
+           private: yes
+
+         - name: "ocapi"
+           prompt: "OpenShift API"
+           private: no
+           default: "https://api.cluster-{{ guid }}.dynamic.opentlc.com:6443"
+           #default: https://api.cluster-{{ guid }}.{{ guid }}.example.opentlc.com:6443
+
+  module_defaults:
+      group/k8s:
+        host: "{{ ocapi }}"
+        validate_certs: no
+
+  tasks:
+  - block:
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: "{{ ocadmin }}"
+        password: "{{ ocpass }}"
+      register: k8s_auth_results
+
+    # Previous task provides the token/api_key, while all other parameters
+    # are taken from module_defaults
+    - name: Get a list of all nodes from any namespace
+      k8s_info:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        kind: Node
+      register: node_list
+
+    - name: debug output cluster nodes
+      debug:
+        var: node_list.resources
+
+    - name: get type of variable
+      debug:
+              msg: "node_list.resources: {{ node_list.resources | type_debug }}"
+
+    - name: get nodenames
+      debug:
+              msg: "Name: {{ info.metadata.name }} is unschedulable: {{ info.spec.unschedulable | default(false) }}"
+      when: '"node-role.kubernetes.io/worker" in info.metadata.labels'
+      loop: "{{ node_list.resources  }}"
+      loop_control:
+            loop_var: info
+            label: "{{ info.metadata.uid }}"
+
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+

--- a/demo/ocp-prep-nodes.yml
+++ b/demo/ocp-prep-nodes.yml
@@ -1,0 +1,69 @@
+---
+- name: Prepare OCP Worker Nodes for SDI
+  hosts: ocp
+
+  vars_prompt:
+         - name: "guid"
+           prompt: "Enter GUID"
+           private: no
+           default: "{{ lookup('env', 'GUID') }}"
+
+         - name: "ocadmin"
+           prompt: "User"
+           private: no
+           default: "admin"
+
+         - name: "ocpass"
+           prompt: "password"
+           private: yes
+
+         - name: "ocapi"
+           prompt: "OpenShift API"
+           private: no
+           default: "https://api.cluster-{{ lookup('env', 'GUID') }}.dynamic.opentlc.com:6443"
+           #default: https://api.cluster-{{ guid }}.{{ guid }}.example.opentlc.com:6443
+
+  module_defaults:
+      group/k8s:
+        host: "{{ ocapi }}"
+        validate_certs: no
+
+  tasks:
+  - block:
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: "{{ ocadmin }}"
+        password: "{{ ocpass }}"
+      register: k8s_auth_results
+
+    # Previous task provides the token/api_key, while all other parameters
+    # are taken from module_defaults
+    - name: Get a list of all nodes from any namespace
+      k8s_info:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        kind: Node
+      register: node_list
+
+    - name: Add Nodenames to worker list
+      set_fact:
+            sdi_configure_ocp_worker_nodelist: "{{ sdi_configure_ocp_worker_nodelist | default([]) + [info.metadata.name] }}"
+      when: '"node-role.kubernetes.io/worker" in info.metadata.labels'
+      loop: "{{ node_list.resources }}"
+      loop_control:
+            loop_var: info
+            label: "{{ info.metadata.uid }}"
+
+    - name: Configure Nodes for use with SDI
+      import_role:
+         name: sdi_configure_ocp_worker
+      vars:
+         sdi_configure_ocp_worker_apikey: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+

--- a/demo/ocp-wait-updated-nodes.yml
+++ b/demo/ocp-wait-updated-nodes.yml
@@ -1,0 +1,71 @@
+---
+- name: get OCP node info
+  hosts: ocp
+
+  vars_prompt:
+         - name: "guid"
+           prompt: "Enter GUID"
+           private: no
+           default: "{{ lookup('env', 'GUID') }}"
+
+         - name: "ocadmin"
+           prompt: "User"
+           private: no
+           default: "admin"
+
+         - name: "ocpass"
+           prompt: "password"
+           private: yes
+
+         - name: "ocapi"
+           prompt: "OpenShift API"
+           private: no
+           default: "https://api.cluster-{{ guid }}.dynamic.opentlc.com:6443"
+           #default: https://api.cluster-{{ guid }}.{{ guid }}.example.opentlc.com:6443
+
+  module_defaults:
+      group/k8s:
+        host: "{{ ocapi }}"
+        validate_certs: no
+
+  tasks:
+  - block:
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: "{{ ocadmin }}"
+        password: "{{ ocpass }}"
+      register: k8s_auth_results
+
+    # Previous task provides the token/api_key, while all other parameters
+    # are taken from module_defaults
+    - name: Get a list of all nodes from any namespace
+      k8s_info:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        kind: Node
+      register: node_list
+
+    - name: debug output cluster nodes
+      debug:
+        var: node_list.resources
+
+    - name: get type of variable
+      debug:
+              msg: "node_list.resources: {{ node_list.resources | type_debug }}"
+
+    - name: get nodenames
+      debug:
+              msg: "Name: {{ info.metadata.name }} is unschedulable: {{ info.spec.unschedulable | default(false) }}"
+      when: '"node-role.kubernetes.io/worker" in info.metadata.labels'
+      loop: "{{ node_list.resources  }}"
+      loop_control:
+            loop_var: info
+            label: "{{ info.metadata.uid }}"
+
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+

--- a/demo/ocs-create-S3buckets.yml
+++ b/demo/ocs-create-S3buckets.yml
@@ -1,0 +1,78 @@
+---
+- name: Create OCS buckets for SAP DataHub 
+  hosts: ocp
+
+  vars_prompt:
+         - name: "guid"
+           prompt: "Enter GUID"
+           private: no
+           default: "{{ lookup('env', 'GUID') }}"
+
+         - name: "ocadmin"
+           prompt: "User"
+           private: no
+           default: "admin"
+
+         - name: "ocpass"
+           prompt: "password"
+           private: yes
+
+         - name: "ocapi"
+           prompt: "OpenShift API"
+           private: no
+           default: "https://api.cluster-{{ lookup('env', 'GUID') }}.dynamic.opentlc.com:6443"
+           #default: https://api.cluster-{{ guid }}.{{ guid }}.example.opentlc.com:6443
+
+  module_defaults:
+      group/k8s:
+        host: "{{ ocapi }}"
+        validate_certs: no
+
+  tasks:
+  - block:
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: "{{ ocadmin }}"
+        password: "{{ ocpass }}"
+      register: k8s_auth_results
+
+    - name: Ensure Project is created
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: present
+        api_version: project.openshift.io/v1
+        kind: Project
+        name: sdi-infra
+
+    - name: Ensure S3 buckets are present
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: present
+        namespace: sdi-infra
+        definition:
+           apiVersion: objectbucket.io/v1alpha1
+           kind: ObjectBucketClaim
+           metadata:
+             name: "{{ claimName }}"
+           spec:
+             generateBucketName: "{{ claimName }}"
+             storageClassName: openshift-storage.noobaa.io
+      loop:
+        - sdi-checkpoint-store
+        - sdi-data-lake
+      loop_control:
+        loop_var: claimName
+      register: storageclaim_results
+
+    - name: Output Results
+      debug: 
+        var: storageclaim_results
+
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+

--- a/demo/prep-sdi-project.sh
+++ b/demo/prep-sdi-project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# change to the SDI_NAMESPACE
+oc project "${SDI_NAMESPACE:-sdi}"
+oc adm policy add-scc-to-group anyuid "system:serviceaccounts:$(oc project -q)"
+oc adm policy add-scc-to-user privileged -z "$(oc project -q)-elasticsearch"
+oc adm policy add-scc-to-user privileged -z "$(oc project -q)-fluentd"
+oc adm policy add-scc-to-user privileged -z default
+oc adm policy add-scc-to-user privileged -z mlf-deployment-api
+oc adm policy add-scc-to-user privileged -z vora-vflow-server
+oc adm policy add-scc-to-user privileged -z "vora-vsystem-$(oc project -q)"
+oc adm policy add-scc-to-user privileged -z "vora-vsystem-$(oc project -q)-vrep"
+

--- a/demo/prep_bastion.yml
+++ b/demo/prep_bastion.yml
@@ -1,0 +1,115 @@
+---
+- name: prep bastion
+  hosts: ocp
+  become: yes
+
+  tasks:
+     - name: ensure EPEL RPM Key is loaded
+       rpm_key:
+          state: present
+          key: http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+
+     - name: ensure EPEL is enabled
+       yum:
+         state: present
+         name:  https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+
+     - name: Ensure required packages are available
+       yum:
+         name: 
+           - ansible
+           - jq
+           - python3-pyyaml
+           - python3-urllib3.noarch
+           - python3-requests
+           - python3-requests-oauthlib 
+           - python3-openshift
+           - yum-utils
+
+- name: Ensure sap-serverless and side-by-side will be terminated
+  hosts: ocp
+
+  vars_prompt:
+         - name: "guid"
+           prompt: "Enter GUID"
+           private: no
+           default: "{{ lookup('env', 'GUID') }}"
+
+         - name: "ocadmin"
+           prompt: "User"
+           private: no
+           default: "admin"
+
+         - name: "ocpass"
+           prompt: "password"
+           private: yes
+
+         - name: "ocapi"
+           prompt: "OpenShift API"
+           private: no
+           default: "https://api.cluster-{{ lookup('env', 'GUID') }}.dynamic.opentlc.com:6443"
+           #default: https://api.cluster-{{ guid }}.{{ guid }}.example.opentlc.com:6443
+
+  module_defaults:
+      group/k8s:
+        host: "{{ ocapi }}"
+        validate_certs: no
+
+  tasks:
+  - block:
+    - name: Log in (obtain access token)
+      k8s_auth:
+        username: "{{ ocadmin }}"
+        password: "{{ ocpass }}"
+      register: k8s_auth_results
+
+    - name: delete project
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: absent
+        definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            name: "{{ project }}"
+      loop: 
+          - sap-serverless
+          - side-by-side
+      loop_control:
+            loop_var: project
+
+    ## TODO
+    #
+    # Remove the following operators
+    #
+    # 3scale
+    # serverless
+    # fuse online
+    # camel k
+    - name: delete Camel K Operator
+      k8s:
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+        state: absent
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Operator
+          metadata:
+            name: "{{ op }}"
+      loop:
+          - 3scale-operator.3scale
+          - camel-k.openshift-operators
+          - fuse-online.fuse-online
+          # jaeger-product.openshift-operators
+          # openshift-gitops-operator.openshift-operators
+          # openshift-pipelines-operator-rh.openshift-operators
+          - serverless-operator.openshift-serverless
+      loop_control:
+            loop_var: op
+    always:
+    - name: If login succeeded, try to log out (revoke access token)
+      when: k8s_auth_results.k8s_auth.api_key is defined
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+
+

--- a/demo/roles/sdi_configure_ocp_worker/.travis.yml
+++ b/demo/roles/sdi_configure_ocp_worker/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/demo/roles/sdi_configure_ocp_worker/README.md
+++ b/demo/roles/sdi_configure_ocp_worker/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/demo/roles/sdi_configure_ocp_worker/defaults/main.yml
+++ b/demo/roles/sdi_configure_ocp_worker/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# defaults file for sdi-configure-ocp-worker
+#
+
+# API Key to get access to OpenShift Server
+sdi_configure_ocp_worker_apikey:
+
+# define a List of servers to apply the required changes
+sdi_configure_ocp_worker_nodelist: []

--- a/demo/roles/sdi_configure_ocp_worker/meta/main.yml
+++ b/demo/roles/sdi_configure_ocp_worker/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: Markus Koch
+  description: This role configures OpenShift 4.x worker nodes fro use with SAP Data Intelligence
+  company: Red Hat 
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: Apache-2.0
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: [SAP, SDI, DataIntelligence, OpenShift]
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/demo/roles/sdi_configure_ocp_worker/tasks/main-debug.yml
+++ b/demo/roles/sdi_configure_ocp_worker/tasks/main-debug.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for sdi_configure_ocp_worker
+
+- name: List API-Key
+  debug: 
+    msg: "API KEY: {{ sdi_configure_ocp_worker_apikey }}"
+
+- name: List Nodes
+  debug: 
+    var: sdi_configure_ocp_worker_nodelist
+

--- a/demo/roles/sdi_configure_ocp_worker/tasks/main.yml
+++ b/demo/roles/sdi_configure_ocp_worker/tasks/main.yml
@@ -1,0 +1,144 @@
+---
+# tasks file for sdi_configure_ocp_worker
+
+- name: Ensure variable sdi_configure_ocp_worker_apikey is set
+  fail: 
+    msg: "Please make sure sdi_configure_ocp_worker_apikey is set"
+  when:
+     - (sdi_configure_ocp_worker_apikey is none) or (sdi_configure_ocp_worker_apikey | trim == '')
+
+- name: Ensure variable sdi_configure_ocp_worker_nodelist is set
+  fail: 
+    msg: "Please make sure sdi_configure_ocp_worker_nodelist is set"
+  when:
+     - (sdi_configure_ocp_worker_nodelist is none) or (sdi_configure_ocp_worker_nodelist | trim == '')
+
+- name: List API-Key
+  debug: 
+    msg: "API KEY: {{ sdi_configure_ocp_worker_apikey }}"
+
+- name: List Nodes
+  debug: 
+    var: sdi_configure_ocp_worker_nodelist
+
+- name: Ensure Worker Nodes are labeled for SDI use
+  k8s:
+        api_key: "{{ sdi_configure_ocp_worker_apikey }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: "{{ workernode }}"
+            labels:
+              node-role.kubernetes.io/sdi: ""
+  loop: "{{ sdi_configure_ocp_worker_nodelist|list }}"
+  loop_control:
+            loop_var: workernode
+
+- name: Ensure net-raw capability is enabled for containers on schedulable nodes
+  k8s:
+        api_key: "{{ sdi_configure_ocp_worker_apikey }}"
+        state: present
+        definition:
+          apiVersion: machineconfiguration.openshift.io/v1
+          kind: MachineConfig
+          metadata:
+            labels:
+              machineconfiguration.openshift.io/role: sdi
+            name: 97-crio-net-raw
+          spec:
+            config:
+              ignition:
+                version: 2.2.0
+              storage:
+                files:
+                  - contents:
+                      source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZV0KZGVmYXVsdF9jYXBhYmlsaXRpZXMgPSBbCiAgICAgICAgIkNIT1dOIiwKICAgICAgICAiREFDX09WRVJSSURFIiwKICAgICAgICAiRlNFVElEIiwKICAgICAgICAiRk9XTkVSIiwKICAgICAgICAiU0VUR0lEIiwKICAgICAgICAiU0VUVUlEIiwKICAgICAgICAiU0VUUENBUCIsCiAgICAgICAgIk5FVF9CSU5EX1NFUlZJQ0UiLAogICAgICAgICJLSUxMIiwKICAgICAgICAiTkVUX1JBVyIsCl0K
+                      verification: {}
+                    filesystem: root
+                    mode: 420
+                    path: /etc/crio/crio.conf.d/90-default-capabilities
+
+- name: Ensure needed additional kernel modules are pre-loaded
+  k8s:
+        api_key: "{{ sdi_configure_ocp_worker_apikey }}"
+        state: present
+        definition:
+          apiVersion: machineconfiguration.openshift.io/v1
+          kind: MachineConfig
+          metadata:
+            labels:
+              machineconfiguration.openshift.io/role: sdi
+            name: 75-worker-sap-data-intelligence
+          spec:
+            config:
+              ignition:
+                version: 2.2.0
+              storage:
+                files:
+                  - contents:
+                      source: "data:text/plain;charset=utf-8;base64,bmZzZApuZnN2NAppcF90YWJsZXMKaXB0X1JFRElSRUNUCmlwdF9vd25lcgo="
+                      verification: {}
+                    filesystem: root
+                    mode: 420
+                    path: /etc/modules-load.d/sdi-dependencies.conf
+              systemd:
+                units:
+                  - contents: |
+                      [Unit]
+                      Description=Pre-load kernel modules for SAP Data Intelligence
+                      After=network.target
+          
+                      [Service]
+                      Type=oneshot
+                      ExecStart=/usr/sbin/modprobe iptable_nat
+                      ExecStart=/usr/sbin/modprobe iptable_filter
+                      RemainAfterExit=yes
+          
+                      [Install]
+                      WantedBy=multi-user.target
+                    enabled: true
+                    name: sdi-modules-load.service
+
+- name: Ensure maximum number of PIDs per container
+  k8s:
+        api_key: "{{ sdi_configure_ocp_worker_apikey }}"
+        state: present
+        definition:
+          apiVersion: machineconfiguration.openshift.io/v1
+          kind: ContainerRuntimeConfig
+          metadata:
+            name: sdi-pids-limit
+          spec:
+            machineConfigPoolSelector:
+              matchLabels:
+                workload: sapdataintelligence
+            containerRuntimeConfig:
+              pidsLimit: 16384
+
+- name: Ensure MachineConfigs are associated
+  k8s:
+        api_key: "{{ sdi_configure_ocp_worker_apikey }}"
+        state: present
+        definition:
+          apiVersion: machineconfiguration.openshift.io/v1
+          kind: MachineConfigPool
+          metadata:
+            labels:
+              workload: sapdataintelligence
+            name: sdi
+          spec:
+            machineConfigSelector:
+              matchExpressions:
+                - key: machineconfiguration.openshift.io/role
+                  operator: In
+                  values:
+                    - sdi
+                    - worker
+            nodeSelector:
+              matchExpressions:
+                - key: node-role.kubernetes.io/sdi
+                  operator: Exists
+                - key: node-role.kubernetes.io/master
+                  operator: DoesNotExist 

--- a/demo/roles/sdi_configure_ocp_worker/tests/inventory
+++ b/demo/roles/sdi_configure_ocp_worker/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/demo/roles/sdi_configure_ocp_worker/tests/test.yml
+++ b/demo/roles/sdi_configure_ocp_worker/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - sdi-configure-ocp-worker

--- a/roles
+++ b/roles
@@ -1,0 +1,1 @@
+demo/roles


### PR DESCRIPTION
The demo subdirectory contains the code used in the blog at [OpenSourceres](https://www.opensourcerers.org/2021/05/17/how-to-install-sap-data-intelligence-on-red-hat-openshift/).
I created a role for changing the OCP nodes, which I linked in the main directory but may move into a separate github to publish it on galaxy or in the collection. Hence this link is placed in a separate commit.